### PR TITLE
Migrates emacs configuration to use-package

### DIFF
--- a/.emacs.d/.gitignore
+++ b/.emacs.d/.gitignore
@@ -1,2 +1,4 @@
 elpa
 auto-save-list
+network-security.data
+transient/

--- a/.emacs.d/clojure.el
+++ b/.emacs.d/clojure.el
@@ -1,31 +1,25 @@
-(unless (package-installed-p 'clojure-mode)
-  (package-install 'clojure-mode))
-(unless (package-installed-p 'cider)
-  (package-install 'cider))
-(unless (package-installed-p 'rainbow-delimiters)
-  (package-install 'rainbow-delimiters))
-(unless (package-installed-p 'clj-refactor)
-  (package-install 'clj-refactor))
+(use-package clojure-mode
+  :ensure t
+  :bind (:map clojure-mode-map
+              ("C-c -" . hs-hide-all)
+              ("C-c +" . hs-show-all)
+              ("C-c t" . hs-toggle-hiding))
+  :hook ((clojure-mode-hook . linum-mode)
+         (clojure-mode-hook . show-paren-mode)
+         (clojure-mode-hook . electric-pair-mode)
+         (clojure-mode-hook . hs-minor-mode))
+  :init
+  (setq show-paren-style 'mixed)
+  (setq electric-pair-preserve-balance t)
+  (setq electric-pair-delete-adjacent-pairs t))
 
-(add-hook 'clojure-mode-hook 'rainbow-delimiters-mode)
-(add-hook 'clojure-mode-hook
-          (lambda ()
-            ;; Paren minor mode
-            (show-paren-mode)
-            (setq show-paren-style 'mixed)
+(use-package cider
+  :ensure t)
 
-            ;; ElectricPair minor-mode
-            (electric-pair-mode)
-            (setq electric-pair-preserve-balance t)
-            (setq electric-pair-delete-adjacen-pairs t)
+(use-package rainbow-delimiters
+  :ensure t
+  :hook (clojure-mode-hook . rainbow-delimiters-mode))
 
-            ;; HideShow minor mode
-            (hs-minor-mode)
-            (define-key clojure-mode-map (kbd "\C-c-") 'hs-hide-all)
-            (define-key clojure-mode-map (kbd "\C-c+") 'hs-show-all)
-            (define-key clojure-mode-map (kbd "\C-ct") 'hs-toggle-hiding)
-
-            ;; CljRefactor minor mode
-            (clj-refactor-mode t)))
-
-(add-hook 'clojure-mode-hook 'linum-mode)
+(use-package clj-refactor
+  :ensure t
+  :hook (clojure-mode-hook . clj-refactor-mode))

--- a/.emacs.d/editorconfig.el
+++ b/.emacs.d/editorconfig.el
@@ -1,5 +1,4 @@
-(unless (package-installed-p 'editorconfig)
-  (package-install 'editorconfig))
-
-(load "editorconfig")
-(editorconfig-mode 1)
+(use-package editorconfig
+  :ensure t
+  :config
+  (editorconfig-mode 1))

--- a/.emacs.d/elisp-init.el
+++ b/.emacs.d/elisp-init.el
@@ -1,10 +1,10 @@
-(unless (package-installed-p 'rainbow-delimiters)
-  (package-install 'rainbow-delimiters))
+(use-package rainbow-delimiters
+  :ensure t
+  :hook (emacs-lisp-mode-hook . rainbow-delimiters-mode))
 
 (add-hook 'emacs-lisp-mode-hook
           (lambda ()
             (show-paren-mode)
             (setq show-paren-style 'expression)
-            (rainbow-delimiters-mode)
-            (eldoc-mode)))
-(add-hook 'emacs-lisp-mode-hook 'linum-mode)
+            (eldoc-mode)
+            (linum-mode)))

--- a/.emacs.d/haskell.el
+++ b/.emacs.d/haskell.el
@@ -1,2 +1,4 @@
-(add-hook 'haskell-mode-hook 'turn-on-haskell-doc-mode)
-(add-hook 'haskell-mode-hook 'turn-on-haskell-indentation)
+(use-package haskell-mode
+  :ensure t
+  :hook ((haskel-mode-hook . turn-on-haskell-doc-mode)
+         (haskel-mode-hook . turn-on-haskell-indentation)))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -11,6 +11,8 @@
 (unless package-archive-contents
   (package-refresh-contents))
 
+(setq custom-file null-device)
+
 (custom-set-variables
  '(linum-format "%3d ")
  '(package-selected-packages

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1,7 +1,7 @@
 ;; Setting up Marmalade repo
 (require 'package)
 (add-to-list 'package-archives
-    '("marmalade" . "http://marmalade-repo.org/packages/"))
+             '("marmalade" . "http://marmalade-repo.org/packages/"))
 (add-to-list 'package-archives
              '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 (add-to-list 'package-archives
@@ -10,6 +10,14 @@
 
 (unless package-archive-contents
   (package-refresh-contents))
+
+(custom-set-variables
+ '(linum-format "%3d ")
+ '(package-selected-packages
+   (quote (use-package))))
+
+(package-install-selected-packages)
+(require 'use-package)
 
 ;; Setting up default theme
 (add-to-list 'custom-theme-load-path
@@ -45,10 +53,3 @@
 (load "~/.emacs.d/haskell")
 (load "~/.emacs.d/typescript")
 (load "~/.emacs.d/wakatime")
-
-(custom-set-variables
- '(linum-format "%3d ")
- '(package-selected-packages
-   (quote
-    (perfect-margin wakatime-mode web-mode tide terraform-mode rainbow-delimiters projectile markdown-mode magit editorconfig company clj-refactor))))
-

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -17,7 +17,10 @@
    (quote (use-package))))
 
 (package-install-selected-packages)
+
+;; use-package configuration
 (require 'use-package)
+(setq use-package-hook-name-suffix nil)
 
 ;; Setting up default theme
 (add-to-list 'custom-theme-load-path

--- a/.emacs.d/magit-init.el
+++ b/.emacs.d/magit-init.el
@@ -1,9 +1,3 @@
-(unless (package-installed-p 'magit)
-  (package-install 'magit))
-
-;; Turning on global-magit-file-buffer-mode
-;;(global-magit-file-buffer-mode)
-
-;; Shortcuts
-(global-set-key (kbd "C-x g") 'magit-status)
-
+(use-package magit
+  :ensure t
+  :bind ("C-x g" . 'magit-status))

--- a/.emacs.d/org-mode.el
+++ b/.emacs.d/org-mode.el
@@ -1,21 +1,17 @@
-(require 'org)
-
-;; Configuring task types
-(setq org-todo-keywords
-      '((sequence "TODO(t)" "|" "DONE(d)")
-        (sequence "IN PROGRESS(p)" "|" "CANCELLED(c@/!)" "MEETING(m)")))
-
-;; Configuring agenda files
-(setq org-agenda-files (list "~/.org-agenda/lean-engineering.org"))
-
-(setq org-log-done t)
-
-;; Configuring shortcuts
-(define-key global-map (kbd "<f12>") 'org-agenda)
-(define-key global-map "\C-cl" 'org-store-link)
-(define-key global-map (kbd "<f11>") 'org-capture)
-(define-key global-map (kbd "<f9> i") 'org-agenda-clock-in)
-(define-key global-map (kbd "<f9> o") 'org-agenda-clock-out)
-
-;; Configuring org-mode
-(add-hook 'org-mode-hook 'visual-line-mode)
+(use-package org
+  :ensure t
+  :hook (org-mode-hook visual-line-mode)
+  :mode ("\\.org\\'" . org-mode)
+  :bind (([f12]  . org-agenda)
+         ("C-c c" . org-capture)
+         ("<f9> i" . org-clock-in)
+         ("<f9> o" . org-clock-out))
+  :config
+  (progn
+    ;; Configuring task types
+    (setq org-todo-keywords
+          '((sequence "TODO(t)" "|" "DONE(d)")
+            (sequence "IN PROGRESS(p)" "|" "CANCELLED(c@/!)" "MEETING(m)")))
+    ;; Configuring agenda files
+    (setq org-agenda-files (list "~/.org-agenda/lean-engineering.org"))
+    (setq org-log-done t)))

--- a/.emacs.d/projectile-init.el
+++ b/.emacs.d/projectile-init.el
@@ -1,4 +1,3 @@
-(unless (package-installed-p 'projectile)
-  (package-install 'projectile))
-
-(global-set-key (kbd "C-c pf") 'projectile-find-file)
+(use-package projectile
+  :ensure t
+  :bind ("C-c pf" . 'projectile-find-file))

--- a/.emacs.d/shell.el
+++ b/.emacs.d/shell.el
@@ -1,13 +1,12 @@
-(unless (package-installed-p 'flycheck)
-  (package-install 'flycheck))
-
-;; Configure shellcheck to run on sh files
-(require 'flycheck)
-(flycheck-define-checker sh-shellcheck
+(use-package flycheck
+  :ensure t
+  :hook (sh-mode-hook . flycheck-mode)
+  :init
+  ;; Configure shellcheck to run on sh files
+  (flycheck-define-checker sh-shellcheck
   "A shell script syntax using Shellcheck"
   :command ("shellcheck" "-f" "checkstyle"
             "-s" (eval (symbol-name sh-shell))
             source)
   :modes sh-mode
-  :error-parser flycheck-parse-checkstyle)
-(add-hook 'sh-mode-hook 'flycheck-mode)
+  :error-parser flycheck-parse-checkstyle))  

--- a/.emacs.d/typescript.el
+++ b/.emacs.d/typescript.el
@@ -1,30 +1,16 @@
-(unless (package-installed-p 'tide)
-  (package-install 'tide))
-(unless (package-installed-p 'company)
-  (package-install 'company))
+(use-package company
+  :ensure t)
 
-(defun setup-tide-mode ()
-  (interactive)
-  (tide-setup)
-  (flycheck-mode +1)
-  (setq flycheck-check-syntax-automatically '(save mode-enabled))
-  (eldoc-mode +1)
-  (tide-hl-identifier-mode +1)
-  (company-mode +1)
-  (linum-mode +1))
 
-(setq company-tooltip-align-notations t)
+(use-package tide
+  :ensure t
+  :after  (typescript-mode company flycheck)
+  :hook   ((typescript-mode-hook . tide-setup)
+           (typescript-mode-hook . tide-hl-identifier-mode)
+           (typescript-mode-hook . linum-mode)
+           (before-save-hook . tide-format-before-save)))
 
-(add-hook 'typescript-mode-hook #'setup-tide-mode)
-
-;; TSX
-(unless (package-installed-p 'web-mode)
-  (package-install 'web-mode))
-(require 'web-mode)
-(add-to-list 'auto-mode-alist '("\\.tsx\\'" . web-mode))
-(add-hook 'web-mode-hook
-          (lambda ()
-            (when (string-equal "tsx" (file-name-extension buffer-file-name))
-              (setup-tide-mode))))
-;; enable typescript-tslint checker
-(flycheck-add-mode 'typescript-tslint 'web-mode)
+(use-package web-mode
+  :ensure t
+  :mode   ("\\.tsx\\'" . web-mode)
+  :hook   (web-mode-hook . typescript-mode))

--- a/.emacs.d/wakatime.el
+++ b/.emacs.d/wakatime.el
@@ -1,3 +1,6 @@
-(setq wakatime-api-key (getenv "WAKATIME_API_TOKEN"))
-(setq wakatime-cli-path "/usr/local/bin/wakatime")
-(global-wakatime-mode)
+(use-package wakatime-mode
+  :ensure t
+  :init 
+  (setq wakatime-api-key (getenv "WAKATIME_API_TOKEN"))
+  (setq wakatime-cli-path "/usr/local/bin/wakatime")
+  (global-wakatime-mode))


### PR DESCRIPTION
I'm migrating my emacs configuration to [use-package](https://github.com/jwiegley/use-package) because it provides a cleaner and more modular way to organize my configurations.